### PR TITLE
Add node x86 node selector

### DIFF
--- a/venonactl/pkg/templates/kubernetes/deployment.monitor.yaml
+++ b/venonactl/pkg/templates/kubernetes/deployment.monitor.yaml
@@ -26,6 +26,8 @@ spec:
       {{- if .Monitor.RbacEnabled}}
       serviceAccountName: {{ .Monitor.AppName }}
       {{- end }}
+      nodeSelector:
+        kubernetes.io/arch: amd64
       containers:
       - name: {{ .Monitor.AppName }}
         resources:


### PR DESCRIPTION
If someone installs on a cluster with arm nodes this deployment will try to run there and throw errors. Adding a node selector will prevent that.