### PR TITLE
Customize dind daemon config via Helm

### DIFF
--- a/charts/cf-runtime/Chart.yaml
+++ b/charts/cf-runtime/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cf-runtime
 description: A Helm chart for Codefresh Runner
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "0.1.10"

--- a/charts/cf-runtime/templates/re/dind-daemon-conf.re.yaml
+++ b/charts/cf-runtime/templates/re/dind-daemon-conf.re.yaml
@@ -5,16 +5,4 @@ metadata:
   name: codefresh-dind-config
 data:
   daemon.json: |
-    {
-      "hosts": [ "unix:///var/run/docker.sock",
-                 "tcp://0.0.0.0:1300"],
-      "storage-driver": "overlay2",
-      "tlsverify": true,
-      "tls": true,
-      "tlscacert": "/etc/ssl/cf-client/ca.pem",
-      "tlscert": "/etc/ssl/cf/server-cert.pem",
-      "tlskey": "/etc/ssl/cf/server-key.pem",
-      "insecure-registries" : ["192.168.99.100:5000"],
-      "metrics-addr" : "0.0.0.0:9323",
-      "experimental" : true
-    }
+{{ .Values.re.daemon | toPrettyJson | indent 4 }}

--- a/charts/cf-runtime/templates/re/dind-daemon-conf.re.yaml
+++ b/charts/cf-runtime/templates/re/dind-daemon-conf.re.yaml
@@ -5,4 +5,4 @@ metadata:
   name: codefresh-dind-config
 data:
   daemon.json: |
-{{ .Values.re.daemon | toPrettyJson | indent 4 }}
+{{ .Values.re.dindDaemon | toPrettyJson | indent 4 }}

--- a/charts/cf-runtime/values.yaml
+++ b/charts/cf-runtime/values.yaml
@@ -147,7 +147,7 @@ storage: # Storage parameters for Volume-Provisioner
     # DiskMBpsReadWrite: 100
     
 
-re: {}
+re: 
   # Optionally add an AWS IAM role to your pipelines
   # More info: https://codefresh.io/docs/docs/administration/codefresh-runner/#injecting-aws-arn-roles-into-the-cluster
   ## e.g:
@@ -155,6 +155,20 @@ re: {}
   #   serviceAccount:
   #     annotations:   # will be set on codefresh-engine service account
   #       eks.amazonaws.com/role-arn: "arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>"
+  dindDaemon: # dind daemon config
+    hosts:
+      - unix:///var/run/docker.sock
+      - tcp://0.0.0.0:1300
+    storage-driver: overlay2
+    tlsverify: true
+    tls: true
+    tlscacert: /etc/ssl/cf-client/ca.pem
+    tlscert: /etc/ssl/cf/server-cert.pem
+    tlskey: /etc/ssl/cf/server-key.pem
+    insecure-registries:
+      - 192.168.99.100:5000
+    metrics-addr: 0.0.0.0:9323
+    experimental: true
 
 appProxy: # App-Proxy Deployment
   enabled: false


### PR DESCRIPTION
Allows users of the Helm template to specify their own docker-in-docker daemon configuration by adding any valid [dockerd configuration setting](https://docs.docker.com/engine/reference/commandline/dockerd/) as fields in `re.dindDaemon`.

For example, to change the bridge IP to avoid network conflicts with the default dockerd subnet (`172.17.0.0/16`):

```yaml
re:
  dindDaemon:
    # ... omitted defaults added to values.yaml
    bip: 172.16.0.0/24
```

Any dind pods launched by the runtime will have assigned IPs in the `172.16.0.0/24` subnet and can now route to hosts on `172.17.0.0/24`.