### PR TITLE
Add annotations to dind volume provisioner pod

### DIFF
--- a/.deploy/cf-runtime/templates/volume-provisioner/deployment.dind-volume-provisioner.vp.yaml
+++ b/.deploy/cf-runtime/templates/volume-provisioner/deployment.dind-volume-provisioner.vp.yaml
@@ -12,6 +12,10 @@ spec:
   template:
     metadata:
       labels: {{- include "cf-vp.provisionerLabels" . | nindent 9 }}
+      annotations:
+        {{- range $key, $value := .Values.volumeProvisioner.annotations }}
+        {{ $key }}: {{ $value }}
+        {{- end}}
     spec:
       serviceAccountName: {{ include "cf-vp.fullname" . }}
       {{- if .Values.volumeProvisioner.nodeSelector }}

--- a/.deploy/cf-runtime/values.yaml
+++ b/.deploy/cf-runtime/values.yaml
@@ -68,6 +68,7 @@ volumeProvisioner: # Volume-Provisioner Deployment
   #   PRIVILEGED_CONTAINER: true
   ### https://codefresh.io/docs/docs/administration/codefresh-runner/#installing-on-aks
   # mountAzureJson: true
+  annotations: {} # annotate volume-provisioner pod
 
 storage: # Storage parameters for Volume-Provisioner
   backend: local    # volume type: local(default), ebs, gcedisk or azuredisk


### PR DESCRIPTION
- annotations are useful for equipping pod with extra functionality delivered externally or for auto-discovery 
- currently there's no way to add annotation to `dind volume provisioner` pod from within the helm chart
- this PR add this feature 