### PR TITLE
feat/alonbe/improve_cf_runtime_chart 

### DIFF
--- a/.deploy/cf-runtime/Chart.yaml
+++ b/.deploy/cf-runtime/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cf-runtime
 description: A Helm chart for Codefresh Runner
 type: application
-version: 1.8.0
-appVersion: "1.8.0"
+version: 1.9.2
+appVersion: "1.9.2"

--- a/.deploy/cf-runtime/templates/monitor/secret.monitor.yaml
+++ b/.deploy/cf-runtime/templates/monitor/secret.monitor.yaml
@@ -1,4 +1,4 @@
-{{- if (not .Values.monitor.existingMonitorToken ) -}}
+{{- if and .Values.monitor.enabled (not .Values.monitor.existingMonitorToken ) -}}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/.deploy/cf-runtime/templates/volume-provisioner/_helpers.tpl
+++ b/.deploy/cf-runtime/templates/volume-provisioner/_helpers.tpl
@@ -9,6 +9,10 @@ Expand the name of the chart.
     {{- printf "%s-%s" (include "cf-runtime.fullname" .) "volume-provisioner" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "cf-vp.volumeCleanupCronName" -}}
+    {{- printf "%s-%s" (include "cf-runtime.fullname" .) "volume-cleanup" | trunc 52 | trimSuffix "-" }}
+{{- end }}
+
 {{- define "cf-vp.provisionerName" -}}
     {{- printf "%s-%s" (include "cf-runtime.fullname" .) "volume-provisioner" | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/.deploy/cf-runtime/templates/volume-provisioner/cron-job.dind-volume-cleanup.vp.yaml
+++ b/.deploy/cf-runtime/templates/volume-provisioner/cron-job.dind-volume-cleanup.vp.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ include "cf-vp.fullname" . }}
+  name: {{ include "cf-vp.volumeCleanupCronName" . }}
   labels: {{- include "cf-vp.cleanupLabels" . | nindent 4 }}
 spec:
   schedule: "0,10,20,30,40,50 * * * *"

--- a/.deploy/cf-runtime/values.yaml
+++ b/.deploy/cf-runtime/values.yaml
@@ -24,7 +24,7 @@ dockerRegistry: "quay.io" # Registry prefix for the runtime images (default quay
 newRelicLicense: "" # NEWRELIC_LICENSE_KEY (for app-proxy and runner deployments)
 
 runner: # Runner Deployment
-  image: "codefresh/venona:1.8.0"
+  image: "codefresh/venona:1.9.2"
   env: {}
   ## e.g:
   # env:


### PR DESCRIPTION
- Check if monitor is enabled before creating monitor secret
- trunc volume cleanup cron name to make sure it's not more than 52 chars by k8s limit