### PR TITLE
Runner pod - adding optional annotations

### DIFF
--- a/.deploy/cf-runtime/Chart.yaml
+++ b/.deploy/cf-runtime/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Codefresh Runner
 name: cf-runtime
-version: 1.0.7
+version: 1.0.8
 home: https://github.com/codefresh-io/venona
 kubeVersion: '>=1.19.0-0'
 keywords:

--- a/.deploy/cf-runtime/README.md
+++ b/.deploy/cf-runtime/README.md
@@ -1,6 +1,6 @@
 ## Codefresh Runner
 
-![Version: 1.0.7](https://img.shields.io/badge/Version-1.0.7-informational?style=flat-square)
+![Version: 1.0.8](https://img.shields.io/badge/Version-1.0.8-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -91,6 +91,7 @@ Kubernetes: `>=1.19.0-0`
 | re.dindDaemon.tlskey | string | `"/etc/ssl/cf/server-key.pem"` |  |
 | re.dindDaemon.tlsverify | bool | `true` |  |
 | re.serviceAccount | object | `{"annotations":{}}` | Set annotation on engine Service Account Ref: https://codefresh.io/docs/docs/administration/codefresh-runner/#injecting-aws-arn-roles-into-the-cluster |
+| runner.annotations | object | `{}` | Add annotations to runner pod |
 | runner.env | object | `{}` | Add additional env vars |
 | runner.image | string | `"codefresh/venona:1.9.16"` | Set runner image |
 | runner.nodeSelector | object | `{}` | Set runner node selector |

--- a/.deploy/cf-runtime/templates/re/service-account.re.yaml
+++ b/.deploy/cf-runtime/templates/re/service-account.re.yaml
@@ -8,5 +8,5 @@ metadata:
   annotations: 
     {{- range $key, $value := .Values.re.serviceAccount.annotations }}
     {{ $key }}: {{ $value }}
-  {{- end}}
+    {{- end}}
 {{- end}}

--- a/.deploy/cf-runtime/templates/venona/deployment.runner.yaml
+++ b/.deploy/cf-runtime/templates/venona/deployment.runner.yaml
@@ -16,6 +16,10 @@ spec:
   template:
     metadata:
       labels: {{- include "cf-runner.labels" . | nindent 8 }}
+      annotations:
+        {{- range $key, $value := .Values.runner.annotations }}
+        {{ $key }}: {{ $value }}
+        {{- end}}
     spec:
       serviceAccountName: {{ include "cf-runner.fullname" . }}
       {{- if .Values.runner.nodeSelector }}

--- a/.deploy/cf-runtime/templates/volume-provisioner/service-account.dind-volume-provisioner.vp.yaml
+++ b/.deploy/cf-runtime/templates/volume-provisioner/service-account.dind-volume-provisioner.vp.yaml
@@ -7,5 +7,5 @@ metadata:
 {{- if .Values.volumeProvisioner.serviceAccount }}
     {{- range $key, $value := .Values.volumeProvisioner.serviceAccount.annotations }}
     {{ $key }}: {{ $value }}
-  {{- end}}
+    {{- end}}
 {{- end}}

--- a/.deploy/cf-runtime/templates/volume-provisioner/storageclass.dind-volume-provisioner.vp.yaml
+++ b/.deploy/cf-runtime/templates/volume-provisioner/storageclass.dind-volume-provisioner.vp.yaml
@@ -8,7 +8,7 @@ metadata:
   {{/*  annotations:*/}}
   {{/*    {{ range $key, $value := .Values.Storage.Annotations }}*/}}
   {{/*    {{ $key }}: {{ $value }}*/}}
-  {{/*  {{ end }}*/}}
+  {{/*    {{ end }}*/}}
 provisioner: {{ include "cf-vp.volumeProvisionerName" . }}
 parameters:
   {{- if eq .Values.storage.backend "local" }}

--- a/.deploy/cf-runtime/values.yaml
+++ b/.deploy/cf-runtime/values.yaml
@@ -61,6 +61,9 @@ runner:
   #   operator: Equal
   #   value: dind
   #   effect: NoSchedule
+  
+  # -- Add annotations to runner pod
+  annotations: {}
 
 # Volume Provisioner parameters
 # @default -- See below


### PR DESCRIPTION
## What
Runner pod - adding optional annotations

## Why

We need a custom annotation on the pod in order to be able to collect its logs by datadog

## Notes

- I tested the changes, and the same syntax is already being used [here](https://github.com/codefresh-io/venona/blob/release-1.0/.deploy/cf-runtime/templates/volume-provisioner/deployment.dind-volume-provisioner.vp.yaml#L15)
- This PR also contains alignment fixes for unrelated files

@danielm-codefresh @yaroslav-codefresh @roi-codefresh Tagging you here because you're the last ones to commit in this repo 🙏 