### PR TITLE
fix: remove artifacthub.io/alternativeName annotation

### DIFF
--- a/charts/cf-runtime/Chart.yaml
+++ b/charts/cf-runtime/Chart.yaml
@@ -14,9 +14,9 @@ maintainers:
     url: https://codefresh-io.github.io/
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Major templates refactor
     - kind: added
+      description: Major templates refactor
+    - kind: fixed
       description: Initial helm unit tests
 dependencies:
   - name: cf-common

--- a/charts/cf-runtime/Chart.yaml
+++ b/charts/cf-runtime/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Codefresh Runner
 name: cf-runtime
-version: 2.0.0
+version: 2.0.1
 keywords:
   - codefresh
   - runner

--- a/charts/cf-runtime/Chart.yaml
+++ b/charts/cf-runtime/Chart.yaml
@@ -13,7 +13,6 @@ maintainers:
   - name: codefresh
     url: https://codefresh-io.github.io/
 annotations:
-  artifacthub.io/alternativeName: "runner"
   artifacthub.io/changes: |
     - kind: changed
       description: Major templates refactor

--- a/charts/cf-runtime/README.md
+++ b/charts/cf-runtime/README.md
@@ -1,6 +1,6 @@
 ## Codefresh Runner
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square)
 
 ## Prerequisites
 


### PR DESCRIPTION
## What

Remove `remove artifacthub.io/alternativeName` annotation

## Why

## Notes
