### PR TITLE
Update `dind-volume-provisioner` to v1.34.1

### DIFF
--- a/charts/cf-runtime/Chart.yaml
+++ b/charts/cf-runtime/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Codefresh Runner
 name: cf-runtime
-version: 6.1.5
+version: 6.1.6
 keywords:
   - codefresh
   - runner
@@ -14,8 +14,8 @@ maintainers:
     url: https://codefresh-io.github.io/
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fix delete agent and dind secrets
+    - kind: changed
+      description: Update dind-volume-provisioner v1.34.0 → v1.34.1
 dependencies:
   - name: cf-common
     repository: https://chartmuseum.codefresh.io/cf-common

--- a/charts/cf-runtime/README.md
+++ b/charts/cf-runtime/README.md
@@ -1,6 +1,6 @@
 ## Codefresh Runner
 
-![Version: 6.1.5](https://img.shields.io/badge/Version-6.1.5-informational?style=flat-square)
+![Version: 6.1.6](https://img.shields.io/badge/Version-6.1.6-informational?style=flat-square)
 
 Helm chart for deploying [Codefresh Runner](https://codefresh.io/docs/docs/installation/codefresh-runner/) to Kubernetes.
 
@@ -1022,7 +1022,7 @@ Go to [https://<YOUR_ONPREM_DOMAIN_HERE>/admin/runtime-environments/system](http
 | volumeProvisioner.dind-lv-monitor | object | See below | `dind-lv-monitor` DaemonSet parameters (local volumes cleaner) |
 | volumeProvisioner.enabled | bool | `true` | Enable volume-provisioner |
 | volumeProvisioner.env | object | `{}` | Add additional env vars |
-| volumeProvisioner.image | object | `{"registry":"quay.io","repository":"codefresh/dind-volume-provisioner","tag":"1.34.0"}` | Set image |
+| volumeProvisioner.image | object | `{"registry":"quay.io","repository":"codefresh/dind-volume-provisioner","tag":"1.34.1"}` | Set image |
 | volumeProvisioner.nodeSelector | object | `{}` | Set node selector |
 | volumeProvisioner.podAnnotations | object | `{}` | Set pod annotations |
 | volumeProvisioner.podSecurityContext | object | See below | Set security context for the pod |

--- a/charts/cf-runtime/values.yaml
+++ b/charts/cf-runtime/values.yaml
@@ -170,7 +170,7 @@ volumeProvisioner:
   image:
     registry: quay.io
     repository: codefresh/dind-volume-provisioner
-    tag: 1.34.0
+    tag: 1.34.1
   # -- Add additional env vars
   env: {}
 

--- a/venonactl/pkg/store/store.go
+++ b/venonactl/pkg/store/store.go
@@ -174,7 +174,7 @@ func (s *Values) BuildValues() map[string]interface{} {
 			"AwsAccessKeyId":       "",
 			"AwsSecretAccessKey":   "",
 			"VolumeProvisioner": map[string]interface{}{
-				"Image":          "codefresh/dind-volume-provisioner:1.33.3",
+				"Image":          "codefresh/dind-volume-provisioner:1.34.1",
 				"NodeSelector":   s.KubernetesAPI.NodeSelector,
 				"Resources":      s.VolumeProvisioner.Resources,
 				"MountAzureJson": false,


### PR DESCRIPTION
## What

This updates `dind-volume-provisioner`:
* Helm: v1.34.0 → v1.34.1
* CLI: v1.33.3 → v1.34.1

## Why

v1.34.1 is the most recent version with vulnerabilities fixed.

## Notes

—
