### PR TITLE
fix: fix memory leak in engine

### DIFF
--- a/charts/cf-runtime/Chart.yaml
+++ b/charts/cf-runtime/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Codefresh Runner
 name: cf-runtime
-version: 6.3.13
+version: 6.3.14
 keywords:
   - codefresh
   - runner
@@ -14,8 +14,12 @@ maintainers:
     url: https://codefresh-io.github.io/
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: Upgrade engine to v1.169.7
+    - kind: fixed
+      description: Fix memory leak in engine, caused by delays in container-logger
     - kind: added
-      description: Add exclude blobs option to git clone step
+      description: Add optional logging of outgoing HTTP requests in engine
 dependencies:
   - name: cf-common
     repository: oci://quay.io/codefresh/charts

--- a/charts/cf-runtime/README.md
+++ b/charts/cf-runtime/README.md
@@ -1,6 +1,6 @@
 ## Codefresh Runner
 
-![Version: 6.3.13](https://img.shields.io/badge/Version-6.3.13-informational?style=flat-square)
+![Version: 6.3.14](https://img.shields.io/badge/Version-6.3.14-informational?style=flat-square)
 
 Helm chart for deploying [Codefresh Runner](https://codefresh.io/docs/docs/installation/codefresh-runner/) to Kubernetes.
 
@@ -1034,11 +1034,13 @@ Go to [https://<YOUR_ONPREM_DOMAIN_HERE>/admin/runtime-environments/system](http
 | runtime.dind.userVolumeMounts | object | `{}` | Add extra volume mounts |
 | runtime.dind.userVolumes | object | `{}` | Add extra volumes |
 | runtime.dindDaemon | object | See below | DinD pod daemon config |
-| runtime.engine | object | `{"affinity":{},"command":["npm","run","start"],"env":{},"image":{"registry":"quay.io","repository":"codefresh/engine","tag":"1.169.5"},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"resources":{"limits":{"cpu":"1000m","memory":"2048Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"runtimeImages":{"COMPOSE_IMAGE":"quay.io/codefresh/compose:v2.20.3-1.4.0","CONTAINER_LOGGER_IMAGE":"quay.io/codefresh/cf-container-logger:1.10.3","CR_6177_FIXER":"quay.io/codefresh/alpine:edge","DOCKER_BUILDER_IMAGE":"quay.io/codefresh/cf-docker-builder:1.3.11","DOCKER_PULLER_IMAGE":"quay.io/codefresh/cf-docker-puller:8.0.16","DOCKER_PUSHER_IMAGE":"quay.io/codefresh/cf-docker-pusher:6.0.15","DOCKER_TAG_PUSHER_IMAGE":"quay.io/codefresh/cf-docker-tag-pusher:1.3.13","FS_OPS_IMAGE":"quay.io/codefresh/fs-ops:1.2.3","GC_BUILDER_IMAGE":"quay.io/codefresh/cf-gc-builder:0.5.3","GIT_CLONE_IMAGE":"quay.io/codefresh/cf-git-cloner:10.1.26","KUBE_DEPLOY":"quay.io/codefresh/cf-deploy-kubernetes:16.1.11","PIPELINE_DEBUGGER_IMAGE":"quay.io/codefresh/cf-debugger:1.3.0","TEMPLATE_ENGINE":"quay.io/codefresh/pikolo:0.14.0"},"schedulerName":"","serviceAccount":"codefresh-engine","tolerations":[],"userEnvVars":[]}` | Parameters for Engine pod (aka "pipeline" orchestrator). |
+| runtime.engine | object | `{"affinity":{},"command":["npm","run","start"],"env":{"CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS":"1000","LOG_OUTGOING_HTTP_REQUESTS":"false"},"image":{"registry":"quay.io","repository":"codefresh/engine","tag":"1.169.7"},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"resources":{"limits":{"cpu":"1000m","memory":"2048Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"runtimeImages":{"COMPOSE_IMAGE":"quay.io/codefresh/compose:v2.20.3-1.4.0","CONTAINER_LOGGER_IMAGE":"quay.io/codefresh/cf-container-logger:1.10.3","CR_6177_FIXER":"quay.io/codefresh/alpine:edge","DOCKER_BUILDER_IMAGE":"quay.io/codefresh/cf-docker-builder:1.3.11","DOCKER_PULLER_IMAGE":"quay.io/codefresh/cf-docker-puller:8.0.16","DOCKER_PUSHER_IMAGE":"quay.io/codefresh/cf-docker-pusher:6.0.15","DOCKER_TAG_PUSHER_IMAGE":"quay.io/codefresh/cf-docker-tag-pusher:1.3.13","FS_OPS_IMAGE":"quay.io/codefresh/fs-ops:1.2.3","GC_BUILDER_IMAGE":"quay.io/codefresh/cf-gc-builder:0.5.3","GIT_CLONE_IMAGE":"quay.io/codefresh/cf-git-cloner:10.1.26","KUBE_DEPLOY":"quay.io/codefresh/cf-deploy-kubernetes:16.1.11","PIPELINE_DEBUGGER_IMAGE":"quay.io/codefresh/cf-debugger:1.3.0","TEMPLATE_ENGINE":"quay.io/codefresh/pikolo:0.14.0"},"schedulerName":"","serviceAccount":"codefresh-engine","tolerations":[],"userEnvVars":[]}` | Parameters for Engine pod (aka "pipeline" orchestrator). |
 | runtime.engine.affinity | object | `{}` | Set affinity |
 | runtime.engine.command | list | `["npm","run","start"]` | Set container command. |
-| runtime.engine.env | object | `{}` | Set additional env vars. |
-| runtime.engine.image | object | `{"registry":"quay.io","repository":"codefresh/engine","tag":"1.169.5"}` | Set image. |
+| runtime.engine.env | object | `{"CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS":"1000","LOG_OUTGOING_HTTP_REQUESTS":"false"}` | Set additional env vars. |
+| runtime.engine.env.CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS | string | `"1000"` | Interval to check the exec status in the container-logger |
+| runtime.engine.env.LOG_OUTGOING_HTTP_REQUESTS | string | `"false"` | Enable debug-level logging of outgoing HTTP/HTTPS requests |
+| runtime.engine.image | object | `{"registry":"quay.io","repository":"codefresh/engine","tag":"1.169.7"}` | Set image. |
 | runtime.engine.nodeSelector | object | `{}` | Set node selector. |
 | runtime.engine.podAnnotations | object | `{}` | Set pod annotations. |
 | runtime.engine.podLabels | object | `{}` | Set pod labels. |

--- a/charts/cf-runtime/tests/private-registry/private_registry_test.yaml
+++ b/charts/cf-runtime/tests/private-registry/private_registry_test.yaml
@@ -37,6 +37,8 @@ tests:
                 - run
                 - start
               envVars:
+                CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS: "1000"
+                LOG_OUTGOING_HTTP_REQUESTS: "false"
                 COMPOSE_IMAGE: "somedomain.io/codefresh/compose:tagoverride"
                 CONTAINER_LOGGER_IMAGE: "somedomain.io/codefresh/cf-container-logger:tagoverride"
                 DOCKER_BUILDER_IMAGE: "somedomain.io/codefresh/cf-docker-builder:tagoverride"
@@ -152,4 +154,3 @@ tests:
           path: spec.template.spec.containers[0].image
           pattern: ^somedomain.io/codefresh/.*$
         template: templates/hooks/post-install/job-gencerts-dind.yaml
-

--- a/charts/cf-runtime/tests/runtime/runtime_onprem_test.yaml
+++ b/charts/cf-runtime/tests/runtime/runtime_onprem_test.yaml
@@ -44,7 +44,9 @@ tests:
                 - two
                 - three
               envVars:
+                CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS: "1000"
                 FOO: BAR
+                LOG_OUTGOING_HTTP_REQUESTS: "false"
                 COMPOSE_IMAGE: "quay.io/codefresh/compose:tagoverride"
                 CONTAINER_LOGGER_IMAGE: "quay.io/codefresh/cf-container-logger:tagoverride"
                 DOCKER_BUILDER_IMAGE: "quay.io/codefresh/cf-docker-builder:tagoverride"

--- a/charts/cf-runtime/tests/runtime/runtime_test.yaml
+++ b/charts/cf-runtime/tests/runtime/runtime_test.yaml
@@ -45,7 +45,9 @@ tests:
                 - two
                 - three
               envVars:
+                CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS: "1000"
                 FOO: BAR
+                LOG_OUTGOING_HTTP_REQUESTS: "false"
                 COMPOSE_IMAGE: "quay.io/codefresh/compose:tagoverride"
                 CONTAINER_LOGGER_IMAGE: "quay.io/codefresh/cf-container-logger:tagoverride"
                 DOCKER_BUILDER_IMAGE: "quay.io/codefresh/cf-docker-builder:tagoverride"

--- a/charts/cf-runtime/values.yaml
+++ b/charts/cf-runtime/values.yaml
@@ -499,7 +499,7 @@ runtime:
     image:
       registry: quay.io
       repository: codefresh/engine
-      tag: 1.169.5
+      tag: 1.169.7
     # -- Set container command.
     command:
       - npm
@@ -530,7 +530,11 @@ runtime:
       CR_6177_FIXER: 'quay.io/codefresh/alpine:edge'
       GC_BUILDER_IMAGE: 'quay.io/codefresh/cf-gc-builder:0.5.3'
     # -- Set additional env vars.
-    env: {}
+    env:
+      # -- Interval to check the exec status in the container-logger
+      CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS: '1000'
+      # -- Enable debug-level logging of outgoing HTTP/HTTPS requests
+      LOG_OUTGOING_HTTP_REQUESTS: 'false'
     # -- Set pod annotations.
     podAnnotations: {}
     # -- Set pod labels.


### PR DESCRIPTION
## What

This upgrades `engine` to v1.169.7 with fix for rare memory leak in `engine` caused by delays in `container-logger`. The new version of the `engine` also adds an ability to log outgoing HTTP requests, which is disabled by default.

## Why

Bug fix.

## Notes

—