### PR TITLE
correct-API-key-scope

### DIFF
--- a/charts/cf-runtime/values.yaml
+++ b/charts/cf-runtime/values.yaml
@@ -15,7 +15,7 @@ global:
   codefreshHost: "https://g.codefresh.io"
   # -- User token in plain text (required if `global.codefreshTokenSecretKeyRef` is omitted!)
   # Ref: https://g.codefresh.io/user/settings (see API Keys)
-  # Minimal API key scopes: Runner-Installation(read+write), Agent(read+write), Agents(read+write)
+  # Minimal API key scopes: General, Runner-Installation(read+write), Agent(read+write), Agents(read+write)
   codefreshToken: ""
   # -- User token that references an existing secret containing API key (required if `global.codefreshToken` is omitted!)
   codefreshTokenSecretKeyRef: {}


### PR DESCRIPTION
## What
Added General API key scope to values.yaml comment

## Why
gencerts-dind job failing wihtout this permission

## Notes
