### PR TITLE
fix(deployment-init-container): Update _deployment.yaml to support 3d tools like Vals

### DIFF
--- a/charts/cf-runtime/Chart.yaml
+++ b/charts/cf-runtime/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Codefresh Runner
 name: cf-runtime
-version: 6.3.20
+version: 6.3.21
 keywords:
   - codefresh
   - runner
@@ -14,13 +14,11 @@ maintainers:
     url: https://codefresh-io.github.io/
 annotations:
   # 💡 Do not forget to update this annotation:
-  artifacthub.io/containsSecurityUpdates: "true"
+  # artifacthub.io/containsSecurityUpdates: "true"
   # Supported kinds: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade dind to 26.0.0-1.28.6
-    - kind: security
-      description: Fix some CVE
+      description: Remove extra space in init container command for runner deployment
 dependencies:
   - name: cf-common
     repository: oci://quay.io/codefresh/charts

--- a/charts/cf-runtime/README.md
+++ b/charts/cf-runtime/README.md
@@ -1,6 +1,6 @@
 ## Codefresh Runner
 
-![Version: 6.3.20](https://img.shields.io/badge/Version-6.3.20-informational?style=flat-square)
+![Version: 6.3.21](https://img.shields.io/badge/Version-6.3.21-informational?style=flat-square)
 
 Helm chart for deploying [Codefresh Runner](https://codefresh.io/docs/docs/installation/codefresh-runner/) to Kubernetes.
 

--- a/charts/cf-runtime/templates/_components/runner/_deployment.yaml
+++ b/charts/cf-runtime/templates/_components/runner/_deployment.yaml
@@ -35,8 +35,7 @@ spec:
         - /bin/bash
         args:
         - -ec
-        - |
-          {{ .Files.Get "files/init-runtime.sh" | nindent 10 }}
+        - | {{ .Files.Get "files/init-runtime.sh" | nindent 10 }}
         env:
         {{- include "runner-init.environment-variables" . | nindent 8 }}
         {{- with .Values.init.resources }}


### PR DESCRIPTION
## What
Fixing the init container in the runner deployment template. Removing redundent space that cause issues when using 3d tools like Vals (helmfile/vals)

## Why
There is an issue with your helm chart using 3d tools like Vals (helmfile/vals). You have an extra space which cause "mapping values are not allowed in this context" error in 3d tools reading the template result of the cf-runner helm chart.

This change fixes this bug without changing anything else.

## Notes
We at Honeybook are one of your customers and this issue is a blocker to several of our tasks.

POC:
![image](https://github.com/codefresh-io/venona/assets/28809488/91e5798d-915e-4161-847d-a6bb632ef0fe)

