### PR TITLE
fix(jobs-containers): Update deployment and jobs to support 3d tools like Vals

### DIFF
--- a/charts/cf-runtime/Chart.yaml
+++ b/charts/cf-runtime/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Codefresh Runner
 name: cf-runtime
-version: 6.3.21
+version: 6.3.22
 keywords:
   - codefresh
   - runner
@@ -18,7 +18,9 @@ annotations:
   # Supported kinds: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`:
   artifacthub.io/changes: |
     - kind: changed
-      description: Remove extra space in init container command for runner deployment
+      description: Remove extra space in sidecar container (reconcile-runtime) command for runner deployment
+    - kind: changed
+      description: Remove extra space in container commands for jobs (gencerts-dind/cleanup)
 dependencies:
   - name: cf-common
     repository: oci://quay.io/codefresh/charts

--- a/charts/cf-runtime/README.md
+++ b/charts/cf-runtime/README.md
@@ -1,6 +1,6 @@
 ## Codefresh Runner
 
-![Version: 6.3.21](https://img.shields.io/badge/Version-6.3.21-informational?style=flat-square)
+![Version: 6.3.22](https://img.shields.io/badge/Version-6.3.22-informational?style=flat-square)
 
 Helm chart for deploying [Codefresh Runner](https://codefresh.io/docs/docs/installation/codefresh-runner/) to Kubernetes.
 

--- a/charts/cf-runtime/templates/_components/runner/_deployment.yaml
+++ b/charts/cf-runtime/templates/_components/runner/_deployment.yaml
@@ -76,8 +76,7 @@ spec:
         - /bin/bash
         args:
         - -ec
-        - |
-          {{ .Files.Get "files/reconcile-runtime.sh" | nindent 10 }}
+        - | {{ .Files.Get "files/reconcile-runtime.sh" | nindent 10 }}
         env:
         {{- include "runner-sidecar.environment-variables" . | nindent 8 }}
         {{- with .Values.sidecar.resources }}

--- a/charts/cf-runtime/templates/hooks/post-install/job-gencerts-dind.yaml
+++ b/charts/cf-runtime/templates/hooks/post-install/job-gencerts-dind.yaml
@@ -41,8 +41,7 @@ spec:
         - "/bin/bash"
         args:
         - -ec
-        - |
-          {{ .Files.Get "files/configure-dind-certs.sh" | nindent 10 }}
+        - | {{ .Files.Get "files/configure-dind-certs.sh" | nindent 10 }}
         env:
         - name: NAMESPACE
           value: {{ .Release.Namespace }}

--- a/charts/cf-runtime/templates/hooks/pre-delete/job-cleanup-resources.yaml
+++ b/charts/cf-runtime/templates/hooks/pre-delete/job-cleanup-resources.yaml
@@ -40,8 +40,7 @@ spec:
         - "/bin/bash"
         args:
         - -ec
-        - |
-          {{ .Files.Get "files/cleanup-runtime.sh" | nindent 10 }}
+        - | {{ .Files.Get "files/cleanup-runtime.sh" | nindent 10 }}
         env:
         - name: AGENT_NAME
           value: {{ include "runtime.runtime-environment-spec.agent-name" . }}


### PR DESCRIPTION
## What
Fixing the args of the reconcile-runtime container and the gencerts and cleanup jobs containers. Removing redundent space that cause issues when using 3d tools like Vals (helmfile/vals)

## Why
There is an issue with your helm chart using 3d tools like Vals (helmfile/vals). You have an extra space which cause "mapping values are not allowed in this context" error in 3d tools reading the template result of the cf-runner helm chart.

This change fixes this bug without changing anything else.

## Notes
Not ready yet.

Sorry for creating 2 different pull requests, I didn't expect you will be that fast 💪

POC:
![image](https://github.com/codefresh-io/venona/assets/28809488/91e5798d-915e-4161-847d-a6bb632ef0fe)

