### PR TITLE
build: upgrade `engine`

### DIFF
--- a/charts/cf-runtime/Chart.yaml
+++ b/charts/cf-runtime/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Codefresh Runner
 name: cf-runtime
-version: 6.3.27
+version: 6.3.28
 keywords:
   - codefresh
   - runner
@@ -18,9 +18,9 @@ annotations:
   # Supported kinds: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`:
   artifacthub.io/changes: |
     - kind: changed
-      description: Upgrade the engine to v1.169.13
-    - kind: fixed
-      description: Improve performance of compose images pull
+      description: Upgrade the engine to v1.170.0
+    - kind: added
+      description: Allows to force sequential pull of compose images by engine
 dependencies:
   - name: cf-common
     repository: oci://quay.io/codefresh/charts

--- a/charts/cf-runtime/README.md
+++ b/charts/cf-runtime/README.md
@@ -1,6 +1,6 @@
 ## Codefresh Runner
 
-![Version: 6.3.27](https://img.shields.io/badge/Version-6.3.27-informational?style=flat-square)
+![Version: 6.3.28](https://img.shields.io/badge/Version-6.3.28-informational?style=flat-square)
 
 Helm chart for deploying [Codefresh Runner](https://codefresh.io/docs/docs/installation/codefresh-runner/) to Kubernetes.
 
@@ -1034,14 +1034,15 @@ Go to [https://<YOUR_ONPREM_DOMAIN_HERE>/admin/runtime-environments/system](http
 | runtime.dind.userVolumeMounts | object | `{}` | Add extra volume mounts |
 | runtime.dind.userVolumes | object | `{}` | Add extra volumes |
 | runtime.dindDaemon | object | See below | DinD pod daemon config |
-| runtime.engine | object | `{"affinity":{},"command":["npm","run","start"],"env":{"CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS":"1000","LOGGER_LEVEL":"debug","LOG_OUTGOING_HTTP_REQUESTS":"false"},"image":{"registry":"quay.io","repository":"codefresh/engine","tag":"1.169.13"},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"resources":{"limits":{"cpu":"1000m","memory":"2048Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"runtimeImages":{"COMPOSE_IMAGE":"quay.io/codefresh/compose:v2.20.3-1.4.0","CONTAINER_LOGGER_IMAGE":"quay.io/codefresh/cf-container-logger:1.10.3","CR_6177_FIXER":"quay.io/codefresh/alpine:edge","DOCKER_BUILDER_IMAGE":"quay.io/codefresh/cf-docker-builder:1.3.11","DOCKER_PULLER_IMAGE":"quay.io/codefresh/cf-docker-puller:8.0.17","DOCKER_PUSHER_IMAGE":"quay.io/codefresh/cf-docker-pusher:6.0.15","DOCKER_TAG_PUSHER_IMAGE":"quay.io/codefresh/cf-docker-tag-pusher:1.3.13","FS_OPS_IMAGE":"quay.io/codefresh/fs-ops:1.2.3","GC_BUILDER_IMAGE":"quay.io/codefresh/cf-gc-builder:0.5.3","GIT_CLONE_IMAGE":"quay.io/codefresh/cf-git-cloner:10.1.26","KUBE_DEPLOY":"quay.io/codefresh/cf-deploy-kubernetes:16.1.11","PIPELINE_DEBUGGER_IMAGE":"quay.io/codefresh/cf-debugger:1.3.0","TEMPLATE_ENGINE":"quay.io/codefresh/pikolo:0.14.0"},"schedulerName":"","serviceAccount":"codefresh-engine","tolerations":[],"userEnvVars":[]}` | Parameters for Engine pod (aka "pipeline" orchestrator). |
+| runtime.engine | object | `{"affinity":{},"command":["npm","run","start"],"env":{"CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS":"1000","FORCE_COMPOSE_SERIAL_PULL":"false","LOGGER_LEVEL":"debug","LOG_OUTGOING_HTTP_REQUESTS":"false"},"image":{"registry":"quay.io","repository":"codefresh/engine","tag":"1.170.0"},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"resources":{"limits":{"cpu":"1000m","memory":"2048Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"runtimeImages":{"COMPOSE_IMAGE":"quay.io/codefresh/compose:v2.20.3-1.4.0","CONTAINER_LOGGER_IMAGE":"quay.io/codefresh/cf-container-logger:1.10.3","CR_6177_FIXER":"quay.io/codefresh/alpine:edge","DOCKER_BUILDER_IMAGE":"quay.io/codefresh/cf-docker-builder:1.3.11","DOCKER_PULLER_IMAGE":"quay.io/codefresh/cf-docker-puller:8.0.17","DOCKER_PUSHER_IMAGE":"quay.io/codefresh/cf-docker-pusher:6.0.15","DOCKER_TAG_PUSHER_IMAGE":"quay.io/codefresh/cf-docker-tag-pusher:1.3.13","FS_OPS_IMAGE":"quay.io/codefresh/fs-ops:1.2.3","GC_BUILDER_IMAGE":"quay.io/codefresh/cf-gc-builder:0.5.3","GIT_CLONE_IMAGE":"quay.io/codefresh/cf-git-cloner:10.1.26","KUBE_DEPLOY":"quay.io/codefresh/cf-deploy-kubernetes:16.1.11","PIPELINE_DEBUGGER_IMAGE":"quay.io/codefresh/cf-debugger:1.3.0","TEMPLATE_ENGINE":"quay.io/codefresh/pikolo:0.14.0"},"schedulerName":"","serviceAccount":"codefresh-engine","tolerations":[],"userEnvVars":[]}` | Parameters for Engine pod (aka "pipeline" orchestrator). |
 | runtime.engine.affinity | object | `{}` | Set affinity |
 | runtime.engine.command | list | `["npm","run","start"]` | Set container command. |
-| runtime.engine.env | object | `{"CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS":"1000","LOGGER_LEVEL":"debug","LOG_OUTGOING_HTTP_REQUESTS":"false"}` | Set additional env vars. |
+| runtime.engine.env | object | `{"CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS":"1000","FORCE_COMPOSE_SERIAL_PULL":"false","LOGGER_LEVEL":"debug","LOG_OUTGOING_HTTP_REQUESTS":"false"}` | Set additional env vars. |
 | runtime.engine.env.CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS | string | `"1000"` | Interval to check the exec status in the container-logger |
+| runtime.engine.env.FORCE_COMPOSE_SERIAL_PULL | string | `"false"` | If "true", composition images will be pulled sequentially |
 | runtime.engine.env.LOGGER_LEVEL | string | `"debug"` | Level of logging for engine |
 | runtime.engine.env.LOG_OUTGOING_HTTP_REQUESTS | string | `"false"` | Enable debug-level logging of outgoing HTTP/HTTPS requests |
-| runtime.engine.image | object | `{"registry":"quay.io","repository":"codefresh/engine","tag":"1.169.13"}` | Set image. |
+| runtime.engine.image | object | `{"registry":"quay.io","repository":"codefresh/engine","tag":"1.170.0"}` | Set image. |
 | runtime.engine.nodeSelector | object | `{}` | Set node selector. |
 | runtime.engine.podAnnotations | object | `{}` | Set pod annotations. |
 | runtime.engine.podLabels | object | `{}` | Set pod labels. |

--- a/charts/cf-runtime/tests/private-registry/private_registry_test.yaml
+++ b/charts/cf-runtime/tests/private-registry/private_registry_test.yaml
@@ -38,6 +38,7 @@ tests:
                 - start
               envVars:
                 CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS: "1000"
+                FORCE_COMPOSE_SERIAL_PULL: "false"
                 LOG_OUTGOING_HTTP_REQUESTS: "false"
                 LOGGER_LEVEL: debug
                 COMPOSE_IMAGE: "somedomain.io/codefresh/compose:tagoverride"

--- a/charts/cf-runtime/tests/runtime/runtime_onprem_test.yaml
+++ b/charts/cf-runtime/tests/runtime/runtime_onprem_test.yaml
@@ -46,6 +46,7 @@ tests:
               envVars:
                 CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS: "1000"
                 FOO: BAR
+                FORCE_COMPOSE_SERIAL_PULL: "false"
                 LOG_OUTGOING_HTTP_REQUESTS: "false"
                 LOGGER_LEVEL: debug
                 COMPOSE_IMAGE: "quay.io/codefresh/compose:tagoverride"

--- a/charts/cf-runtime/tests/runtime/runtime_test.yaml
+++ b/charts/cf-runtime/tests/runtime/runtime_test.yaml
@@ -47,6 +47,7 @@ tests:
               envVars:
                 CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS: "1000"
                 FOO: BAR
+                FORCE_COMPOSE_SERIAL_PULL: "false"
                 LOG_OUTGOING_HTTP_REQUESTS: "false"
                 LOGGER_LEVEL: debug
                 COMPOSE_IMAGE: "quay.io/codefresh/compose:tagoverride"

--- a/charts/cf-runtime/values.yaml
+++ b/charts/cf-runtime/values.yaml
@@ -500,7 +500,7 @@ runtime:
     image:
       registry: quay.io
       repository: codefresh/engine
-      tag: 1.169.13
+      tag: 1.170.0
     # -- Set container command.
     command:
       - npm
@@ -534,6 +534,8 @@ runtime:
     env:
       # -- Interval to check the exec status in the container-logger
       CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS: '1000'
+      # -- If "true", composition images will be pulled sequentially
+      FORCE_COMPOSE_SERIAL_PULL: 'false'
       # -- Level of logging for engine
       LOGGER_LEVEL: 'debug'
       # -- Enable debug-level logging of outgoing HTTP/HTTPS requests


### PR DESCRIPTION
## What

This upgrades the `engine` to the most recent version that allows to force sequential pull of compose images.

## Why

—

## Notes

—
