### PR TITLE
fix(engine): fix Runtime Images assignment

### DIFF
--- a/charts/cf-runtime/Chart.yaml
+++ b/charts/cf-runtime/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Codefresh Runner
 name: cf-runtime
-version: 6.3.44
+version: 6.3.45
 keywords:
   - codefresh
   - runner
@@ -14,15 +14,11 @@ maintainers:
     url: https://codefresh-io.github.io/
 annotations:
   # 💡 Do not forget to update this annotation:
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   # Supported kinds: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "engine image upgraded to 1.173.3"
-    - kind: changed
-      description: "Specifying runtime images explicitly is required now for the engine"
-    - kind: security
-      description: "CVE-2024-5535⁠ is fixed in the engine"
+    - kind: fixed
+      description: "Fixed an issue within the RE template that resulted in the lack of certain runtime images from the engine envs"
 dependencies:
   - name: cf-common
     repository: oci://quay.io/codefresh/charts

--- a/charts/cf-runtime/README.md
+++ b/charts/cf-runtime/README.md
@@ -1,6 +1,6 @@
 ## Codefresh Runner
 
-![Version: 6.3.44](https://img.shields.io/badge/Version-6.3.44-informational?style=flat-square)
+![Version: 6.3.45](https://img.shields.io/badge/Version-6.3.45-informational?style=flat-square)
 
 Helm chart for deploying [Codefresh Runner](https://codefresh.io/docs/docs/installation/codefresh-runner/) to Kubernetes.
 

--- a/charts/cf-runtime/templates/runtime/runtime-env-spec-tmpl.yaml
+++ b/charts/cf-runtime/templates/runtime/runtime-env-spec-tmpl.yaml
@@ -38,6 +38,8 @@ runtimeScheduler:
     KUBE_DEPLOY: {{ include "runtime.runtimeImageName" (dict "registry" $imageRegistry "imageFullName" $engineContext.runtimeImages.KUBE_DEPLOY) | squote }}
     PIPELINE_DEBUGGER_IMAGE: {{ include "runtime.runtimeImageName" (dict "registry" $imageRegistry "imageFullName" $engineContext.runtimeImages.PIPELINE_DEBUGGER_IMAGE) | squote }}
     TEMPLATE_ENGINE: {{ include "runtime.runtimeImageName" (dict "registry" $imageRegistry "imageFullName" $engineContext.runtimeImages.TEMPLATE_ENGINE) | squote }}
+    CR_6177_FIXER: {{ include "runtime.runtimeImageName" (dict "registry" $imageRegistry "imageFullName" $engineContext.runtimeImages.CR_6177_FIXER) | squote }}
+    GC_BUILDER_IMAGE: {{ include "runtime.runtimeImageName" (dict "registry" $imageRegistry "imageFullName" $engineContext.runtimeImages.GC_BUILDER_IMAGE) | squote }}
   {{- with $engineContext.userEnvVars }}
   userEnvVars:  {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/cf-runtime/tests/private-registry/private_registry_test.yaml
+++ b/charts/cf-runtime/tests/private-registry/private_registry_test.yaml
@@ -59,6 +59,8 @@ tests:
                 KUBE_DEPLOY: 'somedomain.io/codefresh/cf-deploy-kubernetes:tagoverride'
                 PIPELINE_DEBUGGER_IMAGE: 'somedomain.io/codefresh/cf-debugger:tagoverride'
                 TEMPLATE_ENGINE: 'somedomain.io/codefresh/pikolo:tagoverride'
+                CR_6177_FIXER: 'somedomain.io/codefresh/alpine:edge'
+                GC_BUILDER_IMAGE: 'somedomain.io/codefresh/cf-gc-builder:0.5.3'
               workflowLimits:
                 MAXIMUM_ALLOWED_TIME_BEFORE_PRE_STEPS_SUCCESS: 600
                 MAXIMUM_ALLOWED_WORKFLOW_AGE_BEFORE_TERMINATION: 86400

--- a/charts/cf-runtime/tests/runtime/runtime_onprem_test.yaml
+++ b/charts/cf-runtime/tests/runtime/runtime_onprem_test.yaml
@@ -67,6 +67,8 @@ tests:
                 KUBE_DEPLOY: 'quay.io/codefresh/cf-deploy-kubernetes:tagoverride'
                 PIPELINE_DEBUGGER_IMAGE: 'quay.io/codefresh/cf-debugger:tagoverride'
                 TEMPLATE_ENGINE: 'quay.io/codefresh/pikolo:tagoverride'
+                CR_6177_FIXER: 'quay.io/codefresh/alpine:edge'
+                GC_BUILDER_IMAGE: 'quay.io/codefresh/cf-gc-builder:0.5.3'
               workflowLimits:
                 MAXIMUM_ALLOWED_TIME_BEFORE_PRE_STEPS_SUCCESS: 600
                 MAXIMUM_ALLOWED_WORKFLOW_AGE_BEFORE_TERMINATION: 86400

--- a/charts/cf-runtime/tests/runtime/runtime_test.yaml
+++ b/charts/cf-runtime/tests/runtime/runtime_test.yaml
@@ -68,6 +68,8 @@ tests:
                 KUBE_DEPLOY: 'quay.io/codefresh/cf-deploy-kubernetes:tagoverride'
                 PIPELINE_DEBUGGER_IMAGE: 'quay.io/codefresh/cf-debugger:tagoverride'
                 TEMPLATE_ENGINE: 'quay.io/codefresh/pikolo:tagoverride'
+                CR_6177_FIXER: 'quay.io/codefresh/alpine:edge'
+                GC_BUILDER_IMAGE: 'quay.io/codefresh/cf-gc-builder:0.5.3'
               userEnvVars:
                 - name: ALICE
                   valueFrom:


### PR DESCRIPTION
## What

This fixes an issue within the RE template that resulted in the lack of certain runtime images from the engine envs.

## Why

—

## Notes

—