### PR TITLE
fix: ensure all env var values are quoted

### DIFF
--- a/charts/cf-runtime/Chart.yaml
+++ b/charts/cf-runtime/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Codefresh Runner
 name: cf-runtime
-version: 6.4.6
+version: 6.4.7
 keywords:
   - codefresh
   - runner
@@ -18,7 +18,7 @@ annotations:
   # Supported kinds: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "updated docker-builder version to allow users to specify the qemu image on docker builds"
+      description: "ensure all env vars are quoted for engine and dind pods"
 dependencies:
   - name: cf-common
     repository: oci://quay.io/codefresh/charts

--- a/charts/cf-runtime/README.md
+++ b/charts/cf-runtime/README.md
@@ -1,6 +1,6 @@
 ## Codefresh Runner
 
-![Version: 6.4.6](https://img.shields.io/badge/Version-6.4.6-informational?style=flat-square)
+![Version: 6.4.7](https://img.shields.io/badge/Version-6.4.7-informational?style=flat-square)
 
 Helm chart for deploying [Codefresh Runner](https://codefresh.io/docs/docs/installation/codefresh-runner/) to Kubernetes.
 

--- a/charts/cf-runtime/templates/runtime/runtime-env-spec-tmpl.yaml
+++ b/charts/cf-runtime/templates/runtime/runtime-env-spec-tmpl.yaml
@@ -20,11 +20,7 @@ runtimeScheduler:
   envVars:
   {{- with $engineContext.env }}
     {{- range $key, $val := . }}
-      {{- if or (kindIs "bool" $val) (kindIs "int" $val) (kindIs "float64" $val) }}
     {{ $key }}: {{ $val | squote }}
-      {{- else }}
-    {{ $key }}: {{ $val }}
-      {{- end }}
     {{- end }}
   {{- end }}
     COMPOSE_IMAGE: {{ include "runtime.runtimeImageName" (dict "registry" $imageRegistry "imageFullName" $engineContext.runtimeImages.COMPOSE_IMAGE) | squote }}
@@ -103,11 +99,7 @@ dockerDaemonScheduler:
   {{- with $dindContext.env }}
   envVars:
     {{- range $key, $val := . }}
-      {{- if or (kindIs "bool" $val) (kindIs "int" $val) (kindIs "float64" $val) }}
     {{ $key }}: {{ $val | squote }}
-      {{- else }}
-    {{ $key }}: {{ $val }}
-      {{- end }}
     {{- end }}
   {{- end }}
   cluster:

--- a/charts/cf-runtime/tests/private-registry/private_registry_test.yaml
+++ b/charts/cf-runtime/tests/private-registry/private_registry_test.yaml
@@ -41,12 +41,12 @@ tests:
                 CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS: '1000'
                 DOCKER_REQUEST_TIMEOUT_MS: '30000'
                 FORCE_COMPOSE_SERIAL_PULL: 'false'
-                LOGGER_LEVEL: debug
+                LOGGER_LEVEL: 'debug'
                 LOG_OUTGOING_HTTP_REQUESTS: 'false'
                 METRICS_PROMETHEUS_COLLECT_PROCESS_METRICS: 'false'
                 METRICS_PROMETHEUS_ENABLED: 'true'
                 METRICS_PROMETHEUS_ENABLE_LEGACY_METRICS: 'false'
-                METRICS_PROMETHEUS_HOST: 0.0.0.0
+                METRICS_PROMETHEUS_HOST: '0.0.0.0'
                 METRICS_PROMETHEUS_PORT: '9100'
                 COMPOSE_IMAGE: 'somedomain.io/codefresh/compose:tagoverride'
                 CONTAINER_LOGGER_IMAGE: 'somedomain.io/codefresh/cf-container-logger:tagoverride'

--- a/charts/cf-runtime/tests/runtime/runtime_onprem_test.yaml
+++ b/charts/cf-runtime/tests/runtime/runtime_onprem_test.yaml
@@ -47,14 +47,16 @@ tests:
               envVars:
                 CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS: '1000'
                 DOCKER_REQUEST_TIMEOUT_MS: '30000'
-                FOO: BAR
+                FOO: 'BAR'
+                INT: '123'
+                FLOAT_AS_STRING: '12.34'
                 FORCE_COMPOSE_SERIAL_PULL: 'false'
-                LOGGER_LEVEL: debug
+                LOGGER_LEVEL: 'debug'
                 LOG_OUTGOING_HTTP_REQUESTS: 'false'
                 METRICS_PROMETHEUS_COLLECT_PROCESS_METRICS: 'false'
                 METRICS_PROMETHEUS_ENABLED: 'true'
                 METRICS_PROMETHEUS_ENABLE_LEGACY_METRICS: 'false'
-                METRICS_PROMETHEUS_HOST: 0.0.0.0
+                METRICS_PROMETHEUS_HOST: '0.0.0.0'
                 METRICS_PROMETHEUS_PORT: '9100'
                 COMPOSE_IMAGE: 'quay.io/codefresh/compose:tagoverride'
                 CONTAINER_LOGGER_IMAGE: 'quay.io/codefresh/cf-container-logger:tagoverride'
@@ -117,7 +119,9 @@ tests:
               imagePullPolicy: IfNotPresent
               userAccess: true
               envVars:
-                ALICE: BOB
+                ALICE: 'BOB'
+                INT: '123'
+                FLOAT_AS_STRING: '12.34'
                 DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE: 'true'
               cluster:
                 namespace: codefresh

--- a/charts/cf-runtime/tests/runtime/runtime_onprem_test.yaml
+++ b/charts/cf-runtime/tests/runtime/runtime_onprem_test.yaml
@@ -47,10 +47,10 @@ tests:
               envVars:
                 CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS: '1000'
                 DOCKER_REQUEST_TIMEOUT_MS: '30000'
-                FOO: 'BAR'
-                INT: '123'
                 FLOAT_AS_STRING: '12.34'
+                FOO: 'BAR'
                 FORCE_COMPOSE_SERIAL_PULL: 'false'
+                INT: '123'
                 LOGGER_LEVEL: 'debug'
                 LOG_OUTGOING_HTTP_REQUESTS: 'false'
                 METRICS_PROMETHEUS_COLLECT_PROCESS_METRICS: 'false'
@@ -120,9 +120,9 @@ tests:
               userAccess: true
               envVars:
                 ALICE: 'BOB'
-                INT: '123'
-                FLOAT_AS_STRING: '12.34'
                 DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE: 'true'
+                FLOAT_AS_STRING: '12.34'
+                INT: '123'
               cluster:
                 namespace: codefresh
                 serviceAccount: service-account-override

--- a/charts/cf-runtime/tests/runtime/runtime_onprem_values.yaml
+++ b/charts/cf-runtime/tests/runtime/runtime_onprem_values.yaml
@@ -30,6 +30,8 @@ runtime:
         reuseVolumeSortOrder: pipeline_id
     env:
       ALICE: BOB
+      INT: 123
+      FLOAT_AS_STRING: "12.34"
     podAnnotations:
       karpenter.sh/do-not-evict: "true"
     nodeSelector:
@@ -89,6 +91,8 @@ runtime:
       COSIGN_IMAGE_SIGNER_IMAGE: quay.io/codefresh/cf-cosign-image-signer:tagoverride
     env:
       FOO: BAR
+      INT: 123
+      FLOAT_AS_STRING: "12.34"
     podAnnotations:
       karpenter.sh/do-not-evict: "true"
     nodeSelector:

--- a/charts/cf-runtime/tests/runtime/runtime_test.yaml
+++ b/charts/cf-runtime/tests/runtime/runtime_test.yaml
@@ -48,14 +48,16 @@ tests:
               envVars:
                 CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS: '1000'
                 DOCKER_REQUEST_TIMEOUT_MS: '30000'
-                FOO: BAR
+                FOO: 'BAR'
+                INT_AS_STRING: '123'
+                FLOAT: '12.34'
                 FORCE_COMPOSE_SERIAL_PULL: 'false'
-                LOGGER_LEVEL: debug
+                LOGGER_LEVEL: 'debug'
                 LOG_OUTGOING_HTTP_REQUESTS: 'false'
                 METRICS_PROMETHEUS_COLLECT_PROCESS_METRICS: 'false'
                 METRICS_PROMETHEUS_ENABLED: 'true'
                 METRICS_PROMETHEUS_ENABLE_LEGACY_METRICS: 'false'
-                METRICS_PROMETHEUS_HOST: 0.0.0.0
+                METRICS_PROMETHEUS_HOST: '0.0.0.0'
                 METRICS_PROMETHEUS_PORT: '9100'
                 COMPOSE_IMAGE: 'quay.io/codefresh/compose:tagoverride'
                 CONTAINER_LOGGER_IMAGE: 'quay.io/codefresh/cf-container-logger:tagoverride'
@@ -127,7 +129,9 @@ tests:
               imagePullPolicy: Always
               userAccess: true
               envVars:
-                ALICE: BOB
+                ALICE: 'BOB'
+                INT_AS_STRING: "123"
+                FLOAT: '12.34'
                 DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE: 'true'
               cluster:
                 namespace: codefresh

--- a/charts/cf-runtime/tests/runtime/runtime_test.yaml
+++ b/charts/cf-runtime/tests/runtime/runtime_test.yaml
@@ -48,10 +48,10 @@ tests:
               envVars:
                 CONTAINER_LOGGER_EXEC_CHECK_INTERVAL_MS: '1000'
                 DOCKER_REQUEST_TIMEOUT_MS: '30000'
-                FOO: 'BAR'
-                INT_AS_STRING: '123'
                 FLOAT: '12.34'
+                FOO: 'BAR'
                 FORCE_COMPOSE_SERIAL_PULL: 'false'
+                INT_AS_STRING: '123'
                 LOGGER_LEVEL: 'debug'
                 LOG_OUTGOING_HTTP_REQUESTS: 'false'
                 METRICS_PROMETHEUS_COLLECT_PROCESS_METRICS: 'false'
@@ -130,9 +130,9 @@ tests:
               userAccess: true
               envVars:
                 ALICE: 'BOB'
-                INT_AS_STRING: "123"
-                FLOAT: '12.34'
                 DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE: 'true'
+                FLOAT: '12.34'
+                INT_AS_STRING: '123'
               cluster:
                 namespace: codefresh
                 serviceAccount: service-account-override

--- a/charts/cf-runtime/tests/runtime/runtime_values.yaml
+++ b/charts/cf-runtime/tests/runtime/runtime_values.yaml
@@ -17,6 +17,8 @@ runtime:
         reuseVolumeSortOrder: pipeline_id
     env:
       ALICE: BOB
+      INT_AS_STRING: "123"
+      FLOAT: 12.34
     podAnnotations:
       karpenter.sh/do-not-evict: 'true'
     podLabels:
@@ -79,6 +81,8 @@ runtime:
       COSIGN_IMAGE_SIGNER_IMAGE: quay.io/codefresh/cf-cosign-image-signer:tagoverride
     env:
       FOO: BAR
+      INT_AS_STRING: "123"
+      FLOAT: 12.34
     userEnvVars:
     - name: ALICE
       valueFrom:


### PR DESCRIPTION
## What
Strings are currently not quoted in the envVars sections for engine and dind pods in the helm chart. This is an issue if you put an env value in that is actually an integer or a float but put quotes around it. The helm chart will think it's a string and so leave the value unquoted which will then cause issues when the yaml is parsed inside the runner (in venona's go code).

## Why
Env vars are always strings so we can wrap them all in quotes no matter what type they are. I've removed the type checking code for this reason.

## Notes
Jira: https://codefresh-io.atlassian.net/browse/CR-25435