### PR TITLE
fix: upd venona-tester dependency

### DIFF
--- a/venona/build/Dockerfile.tester
+++ b/venona/build/Dockerfile.tester
@@ -1,10 +1,10 @@
 # quay.io/codefresh/venona-tester
-FROM golang:1.23-alpine3.21
+FROM golang:1.24-alpine3.22
 
 RUN apk -U add --no-cache ca-certificates git make gcc g++ bash && update-ca-certificates
 RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4 && \
     go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0 && \
-    go install github.com/securego/gosec/v2/cmd/gosec@v2.16.0 && \
+    go install github.com/securego/gosec/v2/cmd/gosec@v2.22.5 && \
     go install github.com/google/addlicense@v1.1.1 && \
     go install github.com/github/hub@v2.11.2+incompatible
 


### PR DESCRIPTION
## What

## Why
for fixing "Scan code security issues" step in venona-ci
## Notes
