### PR TITLE
fix: update `get-all-images.sh` script to remove digest part from cf-runtime images

### DIFF
--- a/scripts/get-all-images.sh
+++ b/scripts/get-all-images.sh
@@ -3,4 +3,4 @@ CHARTDIR="${MYDIR}/../charts/cf-runtime"
 VALUESFILE="${MYDIR}/../charts/cf-runtime/.ci/values-ci.yaml"
 OUTPUTFILE=$1
 helm dependency update $CHARTDIR
-helm template --values $VALUESFILE --set global.runtimeName="dummy" $CHARTDIR | grep -E 'image: | dindImage:' | awk -F ': ' '{print $2}' | tr -d '"' | tr -d "'" | sort | uniq > $OUTPUTFILE
+helm template --values $VALUESFILE --set global.runtimeName="dummy" $CHARTDIR | grep -E 'image: | dindImage:' | awk -F ': ' '{print $2}' | tr -d '"' | tr -d "'" | sed 's/@sha256:.*//' | sort | uniq > $OUTPUTFILE


### PR DESCRIPTION
## What
Update get-all-images script to remove digest part from cf-runtime images

## Why
Prisma can't scan images with their digest, see this issue [here](https://codefresh-io.atlassian.net/jira/software/c/projects/CR/boards/75?assignee=712020%3Aae442148-af3f-4dbf-82b1-2d7445b0c0ec&assignee=615d7048071a7200714fa165&selectedIssue=CR-30229)

## Notes
