### PR TITLE
fix: update system/runtime step on venona-helm-chart-ci pipeline

### DIFF
--- a/charts/cf-runtime/.ci/values-system-runtime.yaml
+++ b/charts/cf-runtime/.ci/values-system-runtime.yaml
@@ -5,8 +5,8 @@ runtime:
   agent: false
   inCluster: false
   description: "Test runtime created by venona-helm-chart-ci pipeline"
-  kubeconfigFilePath: /opt/codefresh/kubeconfigs/prod-ue1-runtime-free-1/kubeconfig
-  kubeconfigName: prod-ue1-runtime-free-1
+  kubeconfigFilePath: /opt/codefresh/kubeconfigs/prod-ue1-runtime-paying-1/kubeconfig
+  kubeconfigName: prod-ue1-runtime-paying-1
   dind:
     pvcs:
       dind:


### PR DESCRIPTION
## What
Fix system/runtime step on venona-helm-chart-ci pipeline by changing the used cluster from prod-ue1-runtime-free-1 which was deleted recently to prod-ue1-runtime-paying-1
## Why

## Notes
