### PR TITLE
feat(app-proxy): add ingress.enabled toggle

### DIFF
--- a/charts/cf-runtime/Chart.yaml
+++ b/charts/cf-runtime/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Codefresh Runner
 name: cf-runtime
-version: 10.3.8
+version: 10.3.9
 keywords:
   - codefresh
   - runner
@@ -14,17 +14,11 @@ maintainers:
     url: https://codefresh-io.github.io/
 annotations:
   # 💡 Do not forget to update this annotation:
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   # Supported kinds: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: 'Fixes the bug that was causing steps of type "deploy" to fail while pulling secrets.'
-    - kind: fixed
-      description: 'ECR integration with Service Account uses the region of integration.'
-    - kind: changed
-      description: 'Update "engine" to "3.3.0"'
-    - kind: security
-      description: 'Update "pikolo" to "0.15.7". Security fixes.'
+    - kind: added
+      description: 'Add "appProxy.ingress.enabled" toggle to allow disabling the app-proxy Ingress (e.g. when exposing app-proxy via Gateway API or a custom resource). Defaults to true to preserve existing behavior.'
 dependencies:
   - name: cf-common
     repository: oci://quay.io/codefresh/charts

--- a/charts/cf-runtime/README.md
+++ b/charts/cf-runtime/README.md
@@ -1,6 +1,6 @@
 ## Codefresh Runner
 
-![Version: 10.3.8](https://img.shields.io/badge/Version-10.3.8-informational?style=flat-square)
+![Version: 10.3.9](https://img.shields.io/badge/Version-10.3.9-informational?style=flat-square)
 
 Helm chart for deploying [Codefresh Runner](https://codefresh.io/docs/docs/installation/codefresh-runner/) to Kubernetes.
 
@@ -1228,6 +1228,7 @@ Install the Helm chart
 | appProxy.image | object | `{"digest":"sha256:8e7d27e24d0ec25e4825906359395efef0fe89d89b6c44d5a9fbb7b9dee142e7","registry":"quay.io","repository":"codefresh/cf-app-proxy","tag":"0.1.2"}` | Set image |
 | appProxy.ingress.annotations | object | `{}` | Set extra annotations for ingress object |
 | appProxy.ingress.class | string | `""` | Set ingress class |
+| appProxy.ingress.enabled | bool | `true` | Enable app-proxy ingress. Set to `false` to skip creating the Ingress object, e.g. when exposing app-proxy via Gateway API or a custom resource. |
 | appProxy.ingress.host | string | `""` | Set DNS hostname the ingress will use |
 | appProxy.ingress.pathPrefix | string | `""` | Set path prefix for ingress (keep empty for default `/` path) |
 | appProxy.ingress.tlsSecret | string | `""` | Set k8s tls secret for the ingress object |

--- a/charts/cf-runtime/templates/_components/app-proxy/_ingress.yaml
+++ b/charts/cf-runtime/templates/_components/app-proxy/_ingress.yaml
@@ -1,4 +1,5 @@
 {{- define "app-proxy.resources.ingress" -}}
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -29,4 +30,5 @@ spec:
                 name: {{ include "app-proxy.fullname" . }}
                 port:
                   number: 80
+{{- end }}
 {{- end -}}

--- a/charts/cf-runtime/tests/app-proxy/app-proxy_test.yaml
+++ b/charts/cf-runtime/tests/app-proxy/app-proxy_test.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/quintush/helm-unittest/master/schema/helm-testsuite.json
+suite: app-proxy ingress test
+values:
+  - ../values.yaml
+templates:
+  - templates/app-proxy/ingress.yaml
+release:
+  name: cf-runtime
+  namespace: codefresh
+  revision: 1
+  upgrade: true
+chart:
+  appVersion: 1.0.0
+tests:
+  - it: Renders the app-proxy ingress by default when app-proxy is enabled
+    set:
+      appProxy.enabled: true
+      appProxy.ingress.host: app-proxy.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.rules[0].host
+          value: app-proxy.example.com
+
+  - it: Skips the app-proxy ingress when appProxy.ingress.enabled is false
+    set:
+      appProxy.enabled: true
+      appProxy.ingress.enabled: false
+      appProxy.ingress.host: app-proxy.example.com
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/cf-runtime/values.yaml
+++ b/charts/cf-runtime/values.yaml
@@ -888,6 +888,9 @@ appProxy:
   # Set app-proxy ingress parameters
   # @default -- See below
   ingress:
+    # -- Enable app-proxy ingress. Set to `false` to skip creating the Ingress
+    # object, e.g. when exposing app-proxy via Gateway API or a custom resource.
+    enabled: true
     # -- Set path prefix for ingress (keep empty for default `/` path)
     pathPrefix: ""
     # -- Set ingress class


### PR DESCRIPTION
## What

Adds an `appProxy.ingress.enabled` value (default `true`) that gates the app-proxy `Ingress`.

## Why

Today the app-proxy `Ingress` is rendered unconditionally whenever `appProxy.enabled: true` — there is no way to keep the app-proxy Deployment/Service while opting out of the `Ingress`. This is a problem when exposing app-proxy through **Gateway API** (HTTPRoute) or another custom ingress resource: the chart-managed `Ingress` has to be manually pruned or neutralized (e.g. by blanking `ingress.class`), and it reappears on every `helm upgrade`.

With this toggle you can set `appProxy.ingress.enabled: false` and provide your own routing (e.g. via `extraResources`) without forking the chart.

## Change

- `appProxy.ingress.enabled` added to `values.yaml`, **defaults to `true`** so existing installs are unaffected.
- `templates/_components/app-proxy/_ingress.yaml` renders the `Ingress` only when the flag is set.
- Regenerated the values table in `README.md` and bumped the chart version `10.3.8` → `10.3.9` with an `added` changelog annotation.
- Added `tests/app-proxy/app-proxy_test.yaml` covering both states.

## Testing

```
helm lint .                       # 0 failed
# toggle ON (default):  1 Ingress rendered
# toggle OFF:           0 Ingress rendered, rest of the release unchanged
```

Backward compatible: with the value unset, behavior is identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)