### PR TITLE
feat(dind-volume-provisioner): add EKS Pod Identity support

### DIFF
--- a/charts/cf-runtime/Chart.yaml
+++ b/charts/cf-runtime/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Codefresh Runner
 name: cf-runtime
-version: 10.4.2
+version: 10.5.0
 keywords:
   - codefresh
   - runner
@@ -18,10 +18,10 @@ annotations:
   # Supported kinds: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`:
   artifacthub.io/changes: |
     - kind: changed
-      description: 'Release 10.4.2'
+      description: 'Release 10.5.0'
       links:
         - name: 'Release notes'
-          url: 'https://github.com/codefresh-io/venona/releases/tag/cf-runtime-10.4.2-helm'
+          url: 'https://github.com/codefresh-io/venona/releases/tag/cf-runtime-10.5.0-helm'
 dependencies:
   - name: cf-common
     repository: oci://quay.io/codefresh/charts

--- a/charts/cf-runtime/README.md
+++ b/charts/cf-runtime/README.md
@@ -1434,8 +1434,8 @@ Install the Helm chart
 | runner.tolerations | list | `[]` | Set tolerations |
 | runner.updateStrategy | object | `{"type":"RollingUpdate"}` | Upgrade strategy |
 | runtime | object | See below | Set runtime parameters |
-| runtime.accounts | for On-Premise only | `[]` | Assign accounts to runtime (list of account ids) |
-| runtime.agent | for On-Premise only | `true` | Enable agent |
+| runtime.accounts | list | `[]` | (for On-Premise only) Assign accounts to runtime (list of account ids) |
+| runtime.agent | bool | `true` | (for On-Premise only) Enable agent |
 | runtime.description | string | `""` | Runtime description |
 | runtime.dind | object | `{"affinity":{},"containerSecurityContext":{},"env":{"CLEAN_DOCKER":true,"CLEAN_PERIOD_BUILDS":"5","CLEAN_PERIOD_SECONDS":"21600","DISK_USAGE_THRESHOLD":"0.8","IMAGE_RETAIN_PERIOD":"14400","INODES_USAGE_THRESHOLD":"0.8","VOLUMES_RETAIN_PERIOD":"14400"},"image":{"digest":"sha256:254404ebc775b028d4843abd72e3148ec460a68e44c8e7e3c848377c0c195721","pullPolicy":"IfNotPresent","registry":"quay.io","repository":"codefresh/dind","tag":"3.0.20"},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"podSecurityContext":{},"pvcs":{"dind":{"annotations":{},"name":"dind","reuseVolumeSelector":"codefresh-app,io.codefresh.accountName","reuseVolumeSortOrder":"pipeline_id","storageClassName":"{{ include \"dind-volume-provisioner.storageClassName\" . }}","volumeSize":"16Gi"}},"resources":{"limits":{"cpu":"400m","memory":"800Mi"},"requests":null},"schedulerName":"","serviceAccount":"codefresh-engine","terminationGracePeriodSeconds":30,"tolerations":[],"userAccess":true,"userVolumeMounts":{},"userVolumes":{},"volumePermissions":{"enabled":false,"image":{"digest":"sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40","registry":"docker.io","repository":"alpine","tag":3.23},"resources":{},"securityContext":{"runAsUser":0}}}` | Parameters for DinD (docker-in-docker) pod (aka "runtime" pod). |
 | runtime.dind.affinity | object | `{}` | Set affinity |
@@ -1526,8 +1526,8 @@ Install the Helm chart
 | runtime.engine.workflowLimits.TIME_ENGINE_INACTIVE_UNTIL_UNHEALTHY | int | `60` | Time since the last health check report after which the engine is considered unhealthy; seconds. |
 | runtime.engine.workflowLimits.TIME_INACTIVE_UNTIL_TERMINATION | int | `2700` | Time since the last workflow logs activity after which workflow is terminated; seconds. |
 | runtime.gencerts | object | See below | Parameters for `gencerts-dind` post-upgrade/install hook |
-| runtime.inCluster | for On-Premise only | `true` | Set inCluster runtime |
-| runtime.kubeconfigFilePath | for On-Premise only | `""` | Set kubeconfig name and path |
+| runtime.inCluster | bool | `true` | (for On-Premise only) Set inCluster runtime |
+| runtime.kubeconfigFilePath | string | `""` | (for On-Premise only) Set kubeconfig name and path |
 | runtime.patch | object | See below | Parameters for `runtime-patch` post-upgrade/install hook |
 | runtime.patch.cronjob | object | `{"affinity":{},"enabled":true,"failedJobsHistory":1,"image":{"digest":"sha256:811924d0127e67a02a329817aa714b9a2a23e123b2e39fb41335d961568e8a55","registry":"quay.io","repository":"codefresh/cli","tag":"1.2.3-rootless"},"nodeSelector":{},"podSecurityContext":{},"resources":{},"schedule":"0/5 * * * *","successfulJobsHistory":1,"tolerations":[]}` | CronJob to update the runtime on schedule |
 | runtime.rbac | object | `{"create":true,"rules":[]}` | RBAC parameters |

--- a/charts/cf-runtime/README.md
+++ b/charts/cf-runtime/README.md
@@ -1,6 +1,6 @@
 ## Codefresh Runner
 
-![Version: 10.4.2](https://img.shields.io/badge/Version-10.4.2-informational?style=flat-square)
+![Version: 10.5.0](https://img.shields.io/badge/Version-10.5.0-informational?style=flat-square)
 
 Helm chart for deploying [Codefresh Runner](https://codefresh.io/docs/docs/installation/codefresh-runner/) to Kubernetes.
 
@@ -1434,8 +1434,8 @@ Install the Helm chart
 | runner.tolerations | list | `[]` | Set tolerations |
 | runner.updateStrategy | object | `{"type":"RollingUpdate"}` | Upgrade strategy |
 | runtime | object | See below | Set runtime parameters |
-| runtime.accounts | list | `[]` | (for On-Premise only) Assign accounts to runtime (list of account ids) |
-| runtime.agent | bool | `true` | (for On-Premise only) Enable agent |
+| runtime.accounts | for On-Premise only | `[]` | Assign accounts to runtime (list of account ids) |
+| runtime.agent | for On-Premise only | `true` | Enable agent |
 | runtime.description | string | `""` | Runtime description |
 | runtime.dind | object | `{"affinity":{},"containerSecurityContext":{},"env":{"CLEAN_DOCKER":true,"CLEAN_PERIOD_BUILDS":"5","CLEAN_PERIOD_SECONDS":"21600","DISK_USAGE_THRESHOLD":"0.8","IMAGE_RETAIN_PERIOD":"14400","INODES_USAGE_THRESHOLD":"0.8","VOLUMES_RETAIN_PERIOD":"14400"},"image":{"digest":"sha256:254404ebc775b028d4843abd72e3148ec460a68e44c8e7e3c848377c0c195721","pullPolicy":"IfNotPresent","registry":"quay.io","repository":"codefresh/dind","tag":"3.0.20"},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"podSecurityContext":{},"pvcs":{"dind":{"annotations":{},"name":"dind","reuseVolumeSelector":"codefresh-app,io.codefresh.accountName","reuseVolumeSortOrder":"pipeline_id","storageClassName":"{{ include \"dind-volume-provisioner.storageClassName\" . }}","volumeSize":"16Gi"}},"resources":{"limits":{"cpu":"400m","memory":"800Mi"},"requests":null},"schedulerName":"","serviceAccount":"codefresh-engine","terminationGracePeriodSeconds":30,"tolerations":[],"userAccess":true,"userVolumeMounts":{},"userVolumes":{},"volumePermissions":{"enabled":false,"image":{"digest":"sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40","registry":"docker.io","repository":"alpine","tag":3.23},"resources":{},"securityContext":{"runAsUser":0}}}` | Parameters for DinD (docker-in-docker) pod (aka "runtime" pod). |
 | runtime.dind.affinity | object | `{}` | Set affinity |
@@ -1526,8 +1526,8 @@ Install the Helm chart
 | runtime.engine.workflowLimits.TIME_ENGINE_INACTIVE_UNTIL_UNHEALTHY | int | `60` | Time since the last health check report after which the engine is considered unhealthy; seconds. |
 | runtime.engine.workflowLimits.TIME_INACTIVE_UNTIL_TERMINATION | int | `2700` | Time since the last workflow logs activity after which workflow is terminated; seconds. |
 | runtime.gencerts | object | See below | Parameters for `gencerts-dind` post-upgrade/install hook |
-| runtime.inCluster | bool | `true` | (for On-Premise only) Set inCluster runtime |
-| runtime.kubeconfigFilePath | string | `""` | (for On-Premise only) Set kubeconfig name and path |
+| runtime.inCluster | for On-Premise only | `true` | Set inCluster runtime |
+| runtime.kubeconfigFilePath | for On-Premise only | `""` | Set kubeconfig name and path |
 | runtime.patch | object | See below | Parameters for `runtime-patch` post-upgrade/install hook |
 | runtime.patch.cronjob | object | `{"affinity":{},"enabled":true,"failedJobsHistory":1,"image":{"digest":"sha256:811924d0127e67a02a329817aa714b9a2a23e123b2e39fb41335d961568e8a55","registry":"quay.io","repository":"codefresh/cli","tag":"1.2.3-rootless"},"nodeSelector":{},"podSecurityContext":{},"resources":{},"schedule":"0/5 * * * *","successfulJobsHistory":1,"tolerations":[]}` | CronJob to update the runtime on schedule |
 | runtime.rbac | object | `{"create":true,"rules":[]}` | RBAC parameters |
@@ -1562,7 +1562,7 @@ Install the Helm chart
 | volumeProvisioner.dind-lv-monitor | object | See below | `dind-lv-monitor` DaemonSet parameters (local volumes cleaner) |
 | volumeProvisioner.enabled | bool | `true` | Enable volume-provisioner |
 | volumeProvisioner.env | object | `{}` | Add additional env vars |
-| volumeProvisioner.image | object | `{"digest":"sha256:8a6d07510051bd5566ff09d89cdb7176b1ec0350aa2b717080bbbc394b1dc6c1","registry":"quay.io","repository":"codefresh/dind-volume-provisioner","tag":"2.0.4"}` | Set image |
+| volumeProvisioner.image | object | `{"digest":"sha256:b104d4f9517f65122c6df1bc4caad54196588c4533908b8215a071511a3162ca","registry":"quay.io","repository":"codefresh/dind-volume-provisioner","tag":"2.1.0"}` | Set image |
 | volumeProvisioner.name | string | `""` | Set volume-provisioner deployment name |
 | volumeProvisioner.nodeSelector | object | `{}` | Set node selector |
 | volumeProvisioner.podAnnotations | object | `{}` | Set pod annotations |

--- a/charts/cf-runtime/README.md
+++ b/charts/cf-runtime/README.md
@@ -538,6 +538,80 @@ volumeProvisioner:
       eks.amazonaws.com/role-arn: "arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>"
 ```
 
+4. Assign IAM role to `dind-volume-provisioner` service account via [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)
+
+   a. Make sure the `Amazon EKS Pod Identity Agent` addon is installed on the cluster (once per cluster):
+
+   ```
+   aws eks create-addon --cluster-name <CLUSTER_NAME> --addon-name eks-pod-identity-agent
+   ```
+
+   b. Create a role whose trust policy allows the EKS Pod Identity service to assume it, and attach the minimal [IAM policy](#minimal-iam-policy-for-dind-volume-provisioner) to it.
+
+   Save the trust policy to `trust-policy.json`:
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Principal": { "Service": "pods.eks.amazonaws.com" },
+         "Action": ["sts:AssumeRole", "sts:TagSession"]
+       }
+     ]
+   }
+   ```
+
+   Save the minimal [IAM policy](#minimal-iam-policy-for-dind-volume-provisioner) to `dind-volume-provisioner-policy.json`, then
+   create the role and attach the policy, reading both from the files:
+
+   ```
+   # create the role with the trust policy
+   aws iam create-role \
+     --role-name cf-runtime-volume-provisioner \
+     --assume-role-policy-document file://trust-policy.json
+
+   # attach the permissions policy (inline)
+   aws iam put-role-policy \
+     --role-name cf-runtime-volume-provisioner \
+     --policy-name dind-volume-provisioner-ebs \
+     --policy-document file://dind-volume-provisioner-policy.json
+
+   # role ARN to use in the next step
+   aws iam get-role --role-name cf-runtime-volume-provisioner --query 'Role.Arn' --output text
+   ```
+
+   c. Create the Pod Identity association, linking the service account to the role (replace `<CLUSTER_NAME>`, `<NAMESPACE>` and role ARN).
+   The service account name must match `volumeProvisioner.serviceAccount.name` from the chart values below:
+
+   ```
+   aws eks create-pod-identity-association \
+     --cluster-name <CLUSTER_NAME> \
+     --namespace <NAMESPACE> \
+     --service-account dind-volume-provisioner \
+     --role-arn arn:aws:iam::<ACCOUNT_ID>:role/cf-runtime-volume-provisioner
+   ```
+
+   d. Deploy the chart with the following values (no service account annotation is needed - the association created above binds the role):
+
+```yaml
+storage:
+  # -- Set backend volume type (`local`/`ebs`/`ebs-csi`/`gcedisk`/`azuredisk`)
+  backend: ebs-csi
+
+  ebs:
+    availabilityZone: "us-east-1a"
+
+volumeProvisioner:
+  # -- Service Account parameters
+  serviceAccount:
+    # -- Create service account
+    create: true
+    # -- Override service account name
+    name: cf-runtime-volume-provisioner
+```
+
 > **StorageClass is immutable.** The chart generates a StorageClass from `storage.ebs.*`.
 > Its `parameters` field cannot be changed in place, so if you later modify AZ / volume type
 > and run `helm upgrade`, it fails with `field is immutable`. Delete the StorageClass first,

--- a/charts/cf-runtime/README.md.gotmpl
+++ b/charts/cf-runtime/README.md.gotmpl
@@ -538,6 +538,80 @@ volumeProvisioner:
       eks.amazonaws.com/role-arn: "arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>"
 ```
 
+4. Assign IAM role to `dind-volume-provisioner` service account via [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)
+
+   a. Make sure the `Amazon EKS Pod Identity Agent` addon is installed on the cluster (once per cluster):
+
+   ```
+   aws eks create-addon --cluster-name <CLUSTER_NAME> --addon-name eks-pod-identity-agent
+   ```
+
+   b. Create a role whose trust policy allows the EKS Pod Identity service to assume it, and attach the minimal [IAM policy](#minimal-iam-policy-for-dind-volume-provisioner) to it.
+
+   Save the trust policy to `trust-policy.json`:
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Principal": { "Service": "pods.eks.amazonaws.com" },
+         "Action": ["sts:AssumeRole", "sts:TagSession"]
+       }
+     ]
+   }
+   ```
+
+   Save the minimal [IAM policy](#minimal-iam-policy-for-dind-volume-provisioner) to `dind-volume-provisioner-policy.json`, then
+   create the role and attach the policy, reading both from the files:
+
+   ```
+   # create the role with the trust policy
+   aws iam create-role \
+     --role-name cf-runtime-volume-provisioner \
+     --assume-role-policy-document file://trust-policy.json
+
+   # attach the permissions policy (inline)
+   aws iam put-role-policy \
+     --role-name cf-runtime-volume-provisioner \
+     --policy-name dind-volume-provisioner-ebs \
+     --policy-document file://dind-volume-provisioner-policy.json
+
+   # role ARN to use in the next step
+   aws iam get-role --role-name cf-runtime-volume-provisioner --query 'Role.Arn' --output text
+   ```
+
+   c. Create the Pod Identity association, linking the service account to the role (replace `<CLUSTER_NAME>`, `<NAMESPACE>` and role ARN).
+   The service account name must match `volumeProvisioner.serviceAccount.name` from the chart values below:
+
+   ```
+   aws eks create-pod-identity-association \
+     --cluster-name <CLUSTER_NAME> \
+     --namespace <NAMESPACE> \
+     --service-account dind-volume-provisioner \
+     --role-arn arn:aws:iam::<ACCOUNT_ID>:role/cf-runtime-volume-provisioner
+   ```
+
+   d. Deploy the chart with the following values (no service account annotation is needed - the association created above binds the role):
+
+```yaml
+storage:
+  # -- Set backend volume type (`local`/`ebs`/`ebs-csi`/`gcedisk`/`azuredisk`)
+  backend: ebs-csi
+
+  ebs:
+    availabilityZone: "us-east-1a"
+
+volumeProvisioner:
+  # -- Service Account parameters
+  serviceAccount:
+    # -- Create service account
+    create: true
+    # -- Override service account name
+    name: cf-runtime-volume-provisioner
+```
+
 > **StorageClass is immutable.** The chart generates a StorageClass from `storage.ebs.*`.
 > Its `parameters` field cannot be changed in place, so if you later modify AZ / volume type
 > and run `helm upgrade`, it fails with `field is immutable`. Delete the StorageClass first,

--- a/charts/cf-runtime/values.yaml
+++ b/charts/cf-runtime/values.yaml
@@ -153,8 +153,8 @@ volumeProvisioner:
   image:
     registry: quay.io
     repository: codefresh/dind-volume-provisioner
-    tag: 2.0.4
-    digest: sha256:8a6d07510051bd5566ff09d89cdb7176b1ec0350aa2b717080bbbc394b1dc6c1
+    tag: 2.1.0
+    digest: sha256:b104d4f9517f65122c6df1bc4caad54196588c4533908b8215a071511a3162ca
   # -- Add additional env vars
   env: {}
   # E.g.


### PR DESCRIPTION
<!-- Remove unused sections below. -->

# Changelog

## Changes to the chart

- Bump `dind-volume-provisioner` image to 2.1.0 version

## Features and enhancements

- Added [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) support for `dind-volume-provisioner`

# Related tickets

* Closes CF-2170
